### PR TITLE
fix: exports and funds

### DIFF
--- a/src/server/services/account/account.controller.ts
+++ b/src/server/services/account/account.controller.ts
@@ -220,7 +220,7 @@ export class AccountController {
     }
   }
 
-  @Export(ServerExports.SetBankBalance)
+  @Export(ServerExports.SetBankBalanceByIdentifier)
   async setBankBalanceByIdentifier(
     req: Request<{ amount: number; identifier: string }>,
     res: Response<unknown>,

--- a/web/src/components/Modals/PayInvoice.tsx
+++ b/web/src/components/Modals/PayInvoice.tsx
@@ -60,7 +60,7 @@ const PayInvoiceModal = ({ onClose, invoice }: PayInvoiceModalProps) => {
       .finally(onClose);
   };
 
-  const hasEnoughFunds = (selectedAccount?.balance ?? 0) > invoice.amount;
+  const hasEnoughFunds = (selectedAccount?.balance ?? 0) >= invoice.amount;
 
   return (
     <Paper>


### PR DESCRIPTION
**Pull Request Description**

The export setBankBalanceByIdentifier didn't exist because of a typo.
You couldn't pay a invoice if you had the exact amount needed.

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our contributing document and Code of Conduct?
* [x] Have you checked to ensure there aren't other open for the same update/change?
* [x] Have you built and tested the `resource` in-game after the relevant change?
