### PR TITLE
Adding ATMs support when target.enabled is false

### DIFF
--- a/src/client/lua/interaction.lua
+++ b/src/client/lua/interaction.lua
@@ -25,8 +25,8 @@ CreateThread(function ()
           DrawMarker(2, pos.x, pos.y, pos.z, 0.0, 0.0, 0.0, 0.0, 180.0, 0.0, 0.5, 0.5, 0.3, 255, 255, 255, 50, false, true, 2, nil, nil, false)
 
           if dist <= 3.5 then
-            local text = "Open bank: ~INPUT_PICKUP~"
-            display_help_text(text)
+              text = "Open bank: ~INPUT_PICKUP~"
+              display_help_text(text)
 
             if IsControlJustReleased(0, 38) then
               exports["pefcl"]:openBank()
@@ -46,7 +46,7 @@ CreateThread(function ()
         local dist = #(player_coords - pos)
         
         if dist <= 2.0 then
-          local text = "Open atm: ~INPUT_PICKUP~"
+          text = "Open atm: ~INPUT_PICKUP~"
           display_help_text(text)
 
           if IsControlJustReleased(0, 38) then

--- a/src/client/lua/interaction.lua
+++ b/src/client/lua/interaction.lua
@@ -1,15 +1,16 @@
 local config = json.decode(LoadResourceFile(GetCurrentResourceName(), "config.json"))
 local bank_coords = config.bankBlips.coords
+local atm_props = config.atms.props
+local text
 
-
-function display_help_text()
+function display_help_text(text)
   BeginTextCommandDisplayHelp("STRING")
-  AddTextComponentString("Open bank: ~INPUT_PICKUP~")
+  AddTextComponentString(text)
   EndTextCommandDisplayHelp(0, true, false, -1)
 end
 
 CreateThread(function ()
-    
+
   if not config.target.enabled then
     while true do
       local player_id = PlayerPedId()
@@ -24,7 +25,8 @@ CreateThread(function ()
           DrawMarker(2, pos.x, pos.y, pos.z, 0.0, 0.0, 0.0, 0.0, 180.0, 0.0, 0.5, 0.5, 0.3, 255, 255, 255, 50, false, true, 2, nil, nil, false)
 
           if dist <= 3.5 then
-            display_help_text()
+            local text = "Open bank: ~INPUT_PICKUP~"
+            display_help_text(text)
 
             if IsControlJustReleased(0, 38) then
               exports["pefcl"]:openBank()
@@ -35,6 +37,25 @@ CreateThread(function ()
 
 
           sleep = 0
+        end
+      end
+
+      for i = 1, #atm_props do
+        local prop = GetClosestObjectOfType(player_coords, 5.0, joaat(atm_props[i]), false, false, false)
+        local pos = GetEntityCoords(prop)
+        local dist = #(player_coords - pos)
+        
+        if dist <= 2.0 then
+          local text = "Open atm: ~INPUT_PICKUP~"
+          display_help_text(text)
+
+          if IsControlJustReleased(0, 38) then
+            exports["pefcl"]:openAtm()
+          end
+
+          sleep = 0
+        else
+          ClearHelp(true)
         end
       end
 

--- a/src/client/lua/interaction.lua
+++ b/src/client/lua/interaction.lua
@@ -1,12 +1,11 @@
 local config = json.decode(LoadResourceFile(GetCurrentResourceName(), "config.json"))
 local bank_coords = config.bankBlips.coords
 local atm_props = config.atms.props
-local text
 
 function display_help_text(text)
   BeginTextCommandDisplayHelp("STRING")
   AddTextComponentString(text)
-  EndTextCommandDisplayHelp(0, true, false, -1)
+  EndTextCommandDisplayHelp(0, false, false, -1)
 end
 
 CreateThread(function ()
@@ -20,21 +19,18 @@ CreateThread(function ()
       for i = 1, #bank_coords do
         local pos = bank_coords[i]
 
-        local dist = #(player_coords - vector3(pos.x, pos.y, pos.z))
-        if dist <= 10.0 then
+        local distBank = #(player_coords - vector3(pos.x, pos.y, pos.z))
+        if distBank <= 10.0 then
           DrawMarker(2, pos.x, pos.y, pos.z, 0.0, 0.0, 0.0, 0.0, 180.0, 0.0, 0.5, 0.5, 0.3, 255, 255, 255, 50, false, true, 2, nil, nil, false)
 
-          if dist <= 3.5 then
-              text = "Open bank: ~INPUT_PICKUP~"
-              display_help_text(text)
+          if distBank <= 3.5 then
+            display_help_text("Open bank: ~INPUT_PICKUP~")
+            
 
             if IsControlJustReleased(0, 38) then
               exports["pefcl"]:openBank()
             end
-          else
-            ClearHelp(true)
           end
-
 
           sleep = 0
         end
@@ -43,19 +39,16 @@ CreateThread(function ()
       for i = 1, #atm_props do
         local prop = GetClosestObjectOfType(player_coords, 5.0, joaat(atm_props[i]), false, false, false)
         local pos = GetEntityCoords(prop)
-        local dist = #(player_coords - pos)
+        local distAtm = #(player_coords - pos)
         
-        if dist <= 2.0 then
-          text = "Open atm: ~INPUT_PICKUP~"
-          display_help_text(text)
-
+        if distAtm <= 2.0 then
+          display_help_text("Open atm: ~INPUT_PICKUP~")
+          
           if IsControlJustReleased(0, 38) then
             exports["pefcl"]:openAtm()
           end
 
           sleep = 0
-        else
-          ClearHelp(true)
         end
       end
 


### PR DESCRIPTION
I tried to do something clean, it doesn't display any markers but it'll show Help notification when you're close to an atm

**Pull Request Description**

_Please include a general description of the changes made, why they were necessary, 
and any other general things to note._

**Pull Request Checklist**:
* [X] Have you followed the guidelines in our contributing document and Code of Conduct?
* [X] Have you checked to ensure there aren't other open for the same update/change?
* [X] Have you built and tested the `resource` in-game after the relevant change?
