### PR TITLE
fix(accounts): ui refresh on loadPlayer

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import 'dayjs/locale/sv';
 import React, { useEffect, useState } from 'react';
 import { useNuiEvent } from 'react-fivem-hooks';
 import { useTranslation } from 'react-i18next';
+import { useAtom } from 'jotai';
 import { Route } from 'react-router-dom';
 import './App.css';
 import { useConfig } from './hooks/useConfig';
@@ -22,6 +23,8 @@ import { NUIEvents, UserEvents } from '@typings/Events';
 import Deposit from './views/Deposit/Deposit';
 import { fetchNui } from '@utils/fetchNui';
 import Withdraw from './views/Withdraw/Withdraw';
+import { accountsAtom } from '@data/accounts';
+import { transactionBaseAtom } from '@data/transactions';
 
 dayjs.extend(updateLocale);
 
@@ -47,9 +50,15 @@ const Content = styled.div`
 const App: React.FC = () => {
   const config = useConfig();
   const [hasLoaded, setHasLoaded] = useState(process.env.NODE_ENV === 'development');
+  const [, updateAccounts] = useAtom(accountsAtom);
+  const [, updateTransactions] = useAtom(transactionBaseAtom);
   useNuiEvent({
     event: UserEvents.Loaded,
-    callback: () => setHasLoaded(true),
+    callback: () => {
+      setHasLoaded(true);
+      updateAccounts();
+      updateTransactions();
+    },
   });
 
   useNuiEvent({ event: UserEvents.Unloaded, callback: () => setHasLoaded(false) });


### PR DESCRIPTION
Accounts and transactions in UI used to be displayed from previous character in case of character switch as there was no trigger to reload accounts on `UserEvents.Loaded` nui event.
