### PR TITLE
Fixes: Overflow and target id parsing on handleTransfer

### DIFF
--- a/web/src/components/AccountSelect.tsx
+++ b/web/src/components/AccountSelect.tsx
@@ -169,7 +169,7 @@ const AccountSelect = ({
 
         {externalAccounts.length > 0 && <ListSubheader>{t('External accounts')}</ListSubheader>}
         {externalAccounts.map((account) => (
-          <StyledMenuItem key={account.id} value={`0.${account.id}`}>
+          <StyledMenuItem key={account.id} value={account.id.toString()}>
             <ListItem>
               <Stack p="0rem 0.5rem">
                 <BodyText>{account.name}</BodyText>

--- a/web/src/components/TransferFunds.tsx
+++ b/web/src/components/TransferFunds.tsx
@@ -45,7 +45,9 @@ const TransferFunds: React.FC<{ onClose?(): void }> = ({ onClose }) => {
       message,
       amount: parsedAmount,
       fromAccountId,
-      toAccountId: isExternalTransfer ? toAccountId * 10 : toAccountId,
+      toAccountId: isExternalTransfer
+        ? toAccountId * Math.pow(10, toAccountId.toString().split('.')[1].length)
+        : toAccountId,
     };
 
     try {

--- a/web/src/components/TransferFunds.tsx
+++ b/web/src/components/TransferFunds.tsx
@@ -31,7 +31,7 @@ const TransferFunds: React.FC<{ onClose?(): void }> = ({ onClose }) => {
   const parsedAmount = Number(amount.replace(/\D/g, ''));
   const fromAccount = accounts.find((account) => account.id === fromAccountId);
 
-  const isExternalTransfer = Boolean(toAccountId && toAccountId < 1);
+  const isExternalTransfer = externalAccounts.some((e) => e.id === toAccountId);
   const message = isExternalTransfer ? t('External transfer') : t('Internal transfer');
   const type = isExternalTransfer ? TransferType.External : TransferType.Internal;
 
@@ -45,9 +45,7 @@ const TransferFunds: React.FC<{ onClose?(): void }> = ({ onClose }) => {
       message,
       amount: parsedAmount,
       fromAccountId,
-      toAccountId: isExternalTransfer
-        ? toAccountId * Math.pow(10, toAccountId.toString().split('.')[1].length)
-        : toAccountId,
+      toAccountId: toAccountId,
     };
 
     try {

--- a/web/src/views/accounts/SharedSettings.tsx
+++ b/web/src/views/accounts/SharedSettings.tsx
@@ -91,7 +91,7 @@ const SharedSettings = ({ accountId, isAdmin }: Props) => {
       />
 
       <Stack spacing={5} alignItems="flex-start">
-        <Stack spacing={1.5}>
+        <Stack spacing={1.5} sx={{ maxHeight: 250 }}>
           <Heading5>{t('Account users')}</Heading5>
           <TableContainer component={Paper}>
             <Table sx={{ minWidth: 400 }}>


### PR DESCRIPTION
**Pull Request Description**

Fixes:
- `CreateTransfer` target id parsing
  - If account id used to be higher than 9 was gettin parsed incorrecty. E.g. from ID 15 it used to return 1.5 or id 123 used to return 1.23;
- Overflow with more users on single shared account.


**Pull Request Checklist**:
* [ ] Have you followed the guidelines in our contributing document and Code of Conduct?
* [ ] Have you checked to ensure there aren't other open for the same update/change?
* [ ] Have you built and tested the `resource` in-game after the relevant change?
