### PR TITLE
Fix logging error

### DIFF
--- a/src/server/services/account/account.service.ts
+++ b/src/server/services/account/account.service.ts
@@ -935,7 +935,7 @@ export class AccountService {
       return sharedAccount;
     } catch (err) {
       t.rollback();
-      logger.error('Failed to add user to unique account');
+      logger.error('Failed to remove user from unique account');
     }
   }
 


### PR DESCRIPTION
Noticed this during some troubleshooting, `removeUserFromUniqueAccount` was saying it failed to add a user to an account
